### PR TITLE
Create /media folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN pacman -Sy sudo git --noconfirm && \
 # Required steps otherwise `toolbox` fails to start the container:
 # 1. machine-id must be present in the base image
 # 2. $(whoami) must be in the sudoer list without password
-RUN touch /etc/machine-id
-RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox
+# 3. /media must be present (toolbox tries to remove the folder and create a symlink)
+RUN touch /etc/machine-id && \
+  echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox && \
+  mkdir /media
 
 CMD /bin/bash


### PR DESCRIPTION
### Overview

One of the latest versions of `toolbox`, is launching `rmdir /media`. In Archlinux `base` image, this folder is not present, and the error triggers an exit in `toolbox`:
```
toolbox: running as real user ID 0
toolbox: resolved absolute path for /usr/sbin/toolbox to /usr/bin/toolbox
toolbox: TOOLBOX_PATH is /usr/bin/toolbox
toolbox: XDG_RUNTIME_DIR is unset
toolbox: XDG_RUNTIME_DIR set to /run/user/1000
toolbox: creating /run/.toolboxenv
toolbox: binding /etc/machine-id to /run/host/etc/machine-id
toolbox: creating /run/systemd/journal
toolbox: binding /run/systemd/journal to /run/host/run/systemd/journal
toolbox: creating /var/lib/flatpak
toolbox: binding /var/lib/flatpak to /run/host/var/lib/flatpak
toolbox: creating /var/log/journal
toolbox: binding /var/log/journal to /run/host/var/log/journal
toolbox: creating /var/mnt
toolbox: binding /var/mnt to /run/host/var/mnt
toolbox: redirecting /etc/localtime to /run/host/monitor/localtime
toolbox: making /media a symbolic link to /run/media
rmdir: failed to remove '/media': No such file or directory
toolbox: failed to make /media a symbolic link
```

This PR creates a `/media` folder to prevent `toolbox` from failing. Of course it would be better to contribute back to `toolbox`, but this PR is mostly to continue the experiment and see if it fits my needs.