### PR TITLE
Build using the archlinux image instead of archlinux/base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/archlinux/base:latest
+FROM docker.io/archlinux:latest
 
 ENV NAME=arch-toolbox VERSION=rolling
 LABEL com.github.containers.toolbox="true" \


### PR DESCRIPTION
### Overview

Builds using `archlinux` instead of `archlinux/base` image.