### PR TITLE
Clean $PROMPT_COMMAND not correctly set by toolbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,8 @@ RUN touch /etc/machine-id && \
   echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox && \
   mkdir /media
 
+# Toolbox doesn't set correctly $PROMPT_COMMAND
+# This step unset the variable if it's composed only by white spaces
+RUN sed -i '/PS1/a \\n# Clean \$PROMPT_COMMAND not correctly set by Toolbox\n\[\[ \-z \"\$\{PROMPT_COMMAND// \}\" \]\] && unset PROMPT_COMMAND' /etc/bash.bashrc
+
 CMD /bin/bash


### PR DESCRIPTION
### Overview

Closes #5 

`toolbox` in [sets](https://github.com/containers/toolbox/blob/61efad34bc9adf37c07286dcb60ca01aecb43ffa/profile.d/toolbox.sh#L66) `PROMPT_COMMAND` as follows:
```
PROMPT_COMMAND=" "
```

By having an empty space, the bash operator thinks the variable is not empty, so when it's evaluated in `/etc/bash.bashrc` statement:
```
PROMPT_COMMAND=${PROMPT_COMMAND:+$PROMPT_COMMAND; }'printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
```

it results in adding a `;` at the beginning of the variable, resulting in the following error:
```
bash: PROMPT_COMMAND: line 0: syntax error near unexpected token ;'
bash: PROMPT_COMMAND: line 0: ; printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/~}"'
```

### Solution

This PR uses `sed` to empty `PROMPT_COMMAND` if it has only empty spaces.